### PR TITLE
Port-metadata ingest + band on links endpoint

### DIFF
--- a/Tests/LinksControllerTests.cs
+++ b/Tests/LinksControllerTests.cs
@@ -26,7 +26,7 @@ public class LinksControllerTests
         var networkStateLogger = Substitute.For<ILogger<NetworkStateService>>();
         _networkState = new NetworkStateService(networkStateLogger, configuration);
         
-        _controller = new LinksController(_networkState, _logger);
+        _controller = new LinksController(_networkState, new PortMetadataStore(), _logger);
     }
 
     [Fact]

--- a/Tests/PortMetadataStoreTests.cs
+++ b/Tests/PortMetadataStoreTests.cs
@@ -1,0 +1,49 @@
+using node_api.Models;
+using node_api.Services;
+using Xunit;
+
+namespace Tests;
+
+public class PortMetadataStoreTests
+{
+    [Fact]
+    public void Get_returns_exact_node_port_match_case_insensitively()
+    {
+        var store = new PortMetadataStore();
+        store.Replace([new PortMetadata("GB7RDG", "3", LinkType: "RF", FreqHz: 7051600, Band: "40m",
+            FreqSource: "reported", Mode: "ax.25", Modulation: null, Baud: 300, Bitrate: 300, Usage: "Mixed", Comment: null)]);
+
+        var pm = store.Get("gb7rdg", "3");
+        Assert.NotNull(pm);
+        Assert.Equal("40m", pm!.Band);
+        Assert.Equal(7051600, pm.FreqHz);
+    }
+
+    [Fact]
+    public void Get_falls_back_to_base_call_for_an_ssid_endpoint()
+    {
+        var store = new PortMetadataStore();
+        store.Replace([Meta("GB7RDG", "3", "40m")]);
+
+        // node-api may name the endpoint GB7RDG-2 while we keyed it under the base call.
+        var pm = store.Get("GB7RDG-2", "3");
+        Assert.NotNull(pm);
+        Assert.Equal("40m", pm!.Band);
+    }
+
+    [Fact]
+    public void Replace_swaps_the_whole_set()
+    {
+        var store = new PortMetadataStore();
+        store.Replace([Meta("A", "1", "b1")]);
+        store.Replace([Meta("B", "1", "b2")]);
+
+        Assert.Null(store.Get("A", "1"));   // gone after replace
+        Assert.Equal("b2", store.Get("B", "1")!.Band);
+        Assert.Equal(1, store.Count);
+    }
+
+    private static PortMetadata Meta(string node, string port, string band) =>
+        new(node, port, LinkType: "RF", FreqHz: null, Band: band, FreqSource: null,
+            Mode: null, Modulation: null, Baud: null, Bitrate: null, Usage: null, Comment: null);
+}

--- a/node-api/Controllers/IngestController.cs
+++ b/node-api/Controllers/IngestController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using node_api.Filters;
 using node_api.Services;
 using node_api.Models;
 using System.Text.Json;
@@ -99,6 +100,26 @@ public class IngestController : ControllerBase
     [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
     public Task<IActionResult> IngestDatagramAsync([FromBody] NetworkEventDatagram datagram)
         => IngestTypedDatagramAsync(datagram);
+
+    /// <summary>
+    /// Replace the per-port metadata (band, frequency, mode, bitrate, usage, comment) used to annotate
+    /// links. Authenticated (X-Api-Key); intended for a single trusted source that derives it from
+    /// operator port config/comments. The full set is sent each time and replaces the previous set.
+    /// </summary>
+    [HttpPost("port-metadata")]
+    [IngestApiKey]
+    [Consumes("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public IActionResult IngestPortMetadata(
+        [FromBody] PortMetadata[] items, [FromServices] IPortMetadataStore store)
+    {
+        if (items is null) return BadRequest("Body required.");
+        store.Replace(items);
+        _logger.LogInformation("Ingested {Count} port-metadata records", items.Length);
+        return Ok(new { received = items.Length });
+    }
 
     // ========== Typed Endpoints for Better OpenAPI Documentation ==========
 

--- a/node-api/Controllers/LinksController.cs
+++ b/node-api/Controllers/LinksController.cs
@@ -9,14 +9,39 @@ namespace node_api.Controllers;
 public class LinksController : ControllerBase
 {
     private readonly INetworkStateService _networkState;
+    private readonly IPortMetadataStore _portMetadata;
     private readonly ILogger<LinksController> _logger;
 
     public LinksController(
         INetworkStateService networkState,
+        IPortMetadataStore portMetadata,
         ILogger<LinksController> logger)
     {
         _networkState = networkState;
+        _portMetadata = portMetadata;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// Annotate each link (and its endpoints) with band/frequency/mode from pushed port metadata.
+    /// Transient enrichment of the in-memory state — idempotent and never persisted.
+    /// </summary>
+    private IEnumerable<LinkState> WithBands(IEnumerable<LinkState> links)
+    {
+        foreach (var link in links)
+        {
+            string? linkBand = null;
+            foreach (var endpoint in link.Endpoints.Values)
+            {
+                var pm = _portMetadata.Get(endpoint.Node, endpoint.Port);
+                endpoint.FreqHz = pm?.FreqHz;
+                endpoint.Band = pm?.Band;
+                endpoint.Mode = pm?.Mode;
+                linkBand ??= pm?.Band;
+            }
+            link.Band = linkBand;
+            yield return link;
+        }
     }
 
     /// <summary>
@@ -33,7 +58,7 @@ public class LinksController : ControllerBase
                        !_networkState.IsHiddenCallsign(l.Endpoint2));
         
         _logger.LogInformation("GetAllLinks called, returning {Count} links", links.Count());
-        return Ok(links);
+        return Ok(WithBands(links));
     }
 
     /// <summary>
@@ -68,9 +93,9 @@ public class LinksController : ControllerBase
                        !_networkState.IsHiddenCallsign(l.Endpoint1) &&
                        !_networkState.IsHiddenCallsign(l.Endpoint2));
 
-        _logger.LogInformation("GetLinksByBaseCallsign called for {BaseCallsign}, returning {Count} links", 
+        _logger.LogInformation("GetLinksByBaseCallsign called for {BaseCallsign}, returning {Count} links",
             baseCallsign, links.Count());
-        
-        return Ok(links);
+
+        return Ok(WithBands(links));
     }
 }

--- a/node-api/Filters/IngestApiKeyAttribute.cs
+++ b/node-api/Filters/IngestApiKeyAttribute.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace node_api.Filters;
+
+/// <summary>
+/// Requires a valid <c>X-Api-Key</c> header matching config <c>Ingest:PortFrequencyApiKey</c>. Secure by
+/// default: if no key is configured the endpoint rejects everything. Constant-time comparison.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class IngestApiKeyAttribute : Attribute, IAsyncActionFilter
+{
+    private const string HeaderName = "X-Api-Key";
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        var configured = context.HttpContext.RequestServices
+            .GetRequiredService<IConfiguration>()["Ingest:PortMetadataApiKey"];
+        var provided = context.HttpContext.Request.Headers[HeaderName].ToString();
+
+        if (string.IsNullOrEmpty(configured) || !FixedTimeEquals(provided, configured))
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
+        await next();
+    }
+
+    private static bool FixedTimeEquals(string a, string b) =>
+        CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(a), Encoding.UTF8.GetBytes(b));
+}

--- a/node-api/Models/NetworkState/LinkState.cs
+++ b/node-api/Models/NetworkState/LinkState.cs
@@ -149,7 +149,13 @@ public class LinkState
     }
     
     public Dictionary<string, LinkEndpointState> Endpoints { get; init; } = new();
-    
+
+    /// <summary>
+    /// RF band of the link (e.g. "40m", "2m"), derived from pushed port-frequency metadata. Transient:
+    /// populated per-response, never persisted or dirty-tracked. Null when the band isn't known.
+    /// </summary>
+    public string? Band { get; set; }
+
     // Dirty tracking for persistence optimization
     public bool IsDirty { get; private set; }
     
@@ -207,6 +213,11 @@ public class LinkEndpointState
     public int? FrameQueueMax { get; set; }
     public int? L2RttMs { get; set; }
     public string? Reason { get; set; }
+
+    /// <summary>Frequency/band/mode of this endpoint's port, from pushed metadata. Transient (not persisted).</summary>
+    public long? FreqHz { get; set; }
+    public string? Band { get; set; }
+    public string? Mode { get; set; }
 }
 
 public enum LinkStatus

--- a/node-api/Models/PortMetadata.cs
+++ b/node-api/Models/PortMetadata.cs
@@ -1,0 +1,21 @@
+namespace node_api.Models;
+
+/// <summary>
+/// Full metadata for one node port, pushed in by an external source (packetnodes) that derives it from
+/// operator port config/comments (LinBPQ M0LTEMapInfo / PortFreq and free-text). node-api doesn't
+/// receive port config itself, so this is how a link's band, frequency, mode etc. become known.
+/// Held in memory and refreshed by the periodic push.
+/// </summary>
+public sealed record PortMetadata(
+    string Node,
+    string Port,
+    string? LinkType,
+    long? FreqHz,
+    string? Band,
+    string? FreqSource,
+    string? Mode,
+    string? Modulation,
+    int? Baud,
+    int? Bitrate,
+    string? Usage,
+    string? Comment);

--- a/node-api/Program.cs
+++ b/node-api/Program.cs
@@ -93,6 +93,7 @@ builder.Services.AddSingleton<IDatagramProcessor>(serviceProvider =>
 builder.Services.AddHostedService<RabbitMqConsumer>();
 
 // Register network state services
+builder.Services.AddSingleton<IPortMetadataStore, PortMetadataStore>();
 builder.Services.AddSingleton<INetworkStateService, NetworkStateService>();
 builder.Services.AddSingleton<NetworkStateUpdater>();
 

--- a/node-api/Services/PortMetadataStore.cs
+++ b/node-api/Services/PortMetadataStore.cs
@@ -1,0 +1,44 @@
+using node_api.Models;
+
+namespace node_api.Services;
+
+/// <summary>
+/// In-memory store of per-port metadata, replaced wholesale on each push. On restart it is empty until
+/// the next push (~1 minute), which is fine — it only annotates links, never gates them.
+/// </summary>
+public interface IPortMetadataStore
+{
+    void Replace(IEnumerable<PortMetadata> items);
+    PortMetadata? Get(string node, string port);
+    int Count { get; }
+}
+
+public sealed class PortMetadataStore : IPortMetadataStore
+{
+    private volatile IReadOnlyDictionary<(string Node, string Port), PortMetadata> _map =
+        new Dictionary<(string, string), PortMetadata>();
+
+    public int Count => _map.Count;
+
+    public void Replace(IEnumerable<PortMetadata> items)
+    {
+        var map = new Dictionary<(string, string), PortMetadata>();
+        foreach (var item in items)
+        {
+            if (string.IsNullOrWhiteSpace(item.Node) || string.IsNullOrWhiteSpace(item.Port)) continue;
+            map[(item.Node.ToUpperInvariant(), item.Port)] = item;
+        }
+        _map = map;
+    }
+
+    public PortMetadata? Get(string node, string port)
+    {
+        if (string.IsNullOrEmpty(node) || string.IsNullOrEmpty(port)) return null;
+        if (_map.TryGetValue((node.ToUpperInvariant(), port), out var exact)) return exact;
+
+        // Fall back to the base call: node-api may name an endpoint with an SSID the source keyed under
+        // its base call (e.g. GB7RDG-2 vs GB7RDG), same physical site/port.
+        var dash = node.IndexOf('-');
+        return dash > 0 && _map.TryGetValue((node[..dash].ToUpperInvariant(), port), out var byBase) ? byBase : null;
+    }
+}

--- a/node-api/appsettings.json
+++ b/node-api/appsettings.json
@@ -15,6 +15,10 @@
   "HiddenCallsigns": [
     "M2"
   ],
+  "Ingest": {
+    "//": "Set PortMetadataApiKey via User Secrets or the INGEST__PORTMETADATAAPIKEY env var. Null/empty rejects all port-metadata pushes.",
+    "PortMetadataApiKey": null
+  },
   "MqttSettings": {
     "Host": "node-api.packet.oarc.uk",
     "Port": 1883,


### PR DESCRIPTION
## What

node-api's ingest model has no port frequency/comment data, so links can't be labelled by radio band. This adds a way to feed that in from an external source and surfaces `band` on the links endpoint.

- **`POST /api/ingest/port-metadata`** — authenticated (`X-Api-Key` vs `Ingest:PortMetadataApiKey`), replaces an in-memory `{node,port} → metadata` store. Carries the full M0LTEMapInfo-derived picture: `linkType, freqHz, band, freqSource, mode, modulation, baud, bitrate, usage, comment`. Secure by default — rejects everything if no key is configured; constant-time comparison.
- **`/api/network/links`** now emits `band` per link and `band`/`freqHz`/`mode` per endpoint. Enrichment is transient (never persisted or dirty-tracked), with base-call fallback for SSID'd endpoints (e.g. `GB7RDG-2` resolves to `GB7RDG` port metadata).

The intended poster is **packetnodes**, which derives port frequencies from operator `M0LTEMapInfo` / `PortFreq` and free-text comments — data node-api never receives. A companion pusher there POSTs the full set every ~60s.

## Config

Set the key before deploy (User Secrets or `INGEST__PORTMETADATAAPIKEY` env var). Null/empty ⇒ endpoint rejects all.

## Tests

`PortMetadataStore` (exact + base-call fallback + replace) and existing `LinksController` tests pass (12/12). The unrelated `ReportedTimeExtractionTests` failures are pre-existing (need a live MySQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)